### PR TITLE
Add missing fields to ComicSchema

### DIFF
--- a/docs/esak.rst
+++ b/docs/esak.rst
@@ -100,6 +100,14 @@ esak.stories module
    :undoc-members:
    :show-inheritance:
 
+esak.text\_object module
+------------------------
+
+.. automodule:: esak.text_object
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 esak.urls module
 ----------------
 

--- a/esak/__init__.py
+++ b/esak/__init__.py
@@ -1,5 +1,5 @@
 """Project entry file."""
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 from typing import Optional
 

--- a/esak/character.py
+++ b/esak/character.py
@@ -34,7 +34,7 @@ class CharacterSchema(Schema):
     name = fields.Str()
     description = fields.Str()
     modified = fields.DateTime()
-    resourceURI = fields.Str(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     urls = fields.Nested(urls.UrlsSchema)
     thumbnail = fields.Url()
     comics = fields.Nested(generic_summary.GenericSummarySchema, many=True)

--- a/esak/comic.py
+++ b/esak/comic.py
@@ -29,7 +29,14 @@ class Comic:
 
 
 class ComicSchema(Schema):
-    """Schema for the Comic API."""
+    """
+    Schema for the Comic API.
+
+    .. versionchanged:: 1.3.0
+
+        - Added ``thumbnail`` and ``text_objects`` fields.
+        - Unknowns fields will now be **excluded**.
+    """
 
     id = fields.Int()
     digital_id = fields.Int(data_key="digitalId")

--- a/esak/comic.py
+++ b/esak/comic.py
@@ -111,9 +111,6 @@ class ComicSchema(Schema):
         if "characters" in data:
             data["characters"] = data["characters"]["items"]
 
-        # if "textObjects" in data:
-        #     data["text_objects"] = data["textObjects"]["items"]
-
         if "images" in data:
             data["images"] = [f"{img['path']}.{img['extension']}" for img in data["images"]]
 

--- a/esak/comic.py
+++ b/esak/comic.py
@@ -56,7 +56,7 @@ class ComicSchema(Schema):
     )
     dates = fields.Nested(dates.DatesSchema)
     prices = fields.Nested(prices.PriceSchemas, allow_none=True)
-    # thumbnail
+    thumbnail = fields.Url()
     images = fields.List(fields.Url)
     creators = fields.Nested(generic_summary.GenericSummarySchema, many=True)
     characters = fields.Nested(generic_summary.GenericSummarySchema, many=True)
@@ -110,6 +110,11 @@ class ComicSchema(Schema):
 
         if "diamondCode" in data:
             data["diamondCode"] = str(data["diamondCode"])
+
+        if "thumbnail" in data and data["thumbnail"] is not None:
+            data["thumbnail"] = f"{data['thumbnail']['path']}.{data['thumbnail']['extension']}"
+        else:
+            data["thumbnail"] = None
 
         return data
 

--- a/esak/comic.py
+++ b/esak/comic.py
@@ -12,7 +12,7 @@ import itertools
 from marshmallow import INCLUDE, Schema, fields, post_load, pre_load
 from marshmallow.exceptions import ValidationError
 
-from esak import dates, exceptions, generic_summary, prices, series, urls
+from esak import dates, exceptions, generic_summary, prices, series, text_object, urls
 
 
 class Comic:
@@ -45,7 +45,9 @@ class ComicSchema(Schema):
     issn = fields.Str()
     format = fields.Str()
     page_count = fields.Int(data_key="pageCount")
-    # textObjects
+    text_objects = fields.Nested(
+        text_object.TextObjectSchema, data_key="textObjects", many=True
+    )
     resource_uri = fields.Str(data_key="resourceURI")
     urls = fields.Nested(urls.UrlsSchema)
     series = fields.Nested(series.SeriesSchema)
@@ -101,6 +103,9 @@ class ComicSchema(Schema):
 
         if "characters" in data:
             data["characters"] = data["characters"]["items"]
+
+        # if "textObjects" in data:
+        #     data["text_objects"] = data["textObjects"]["items"]
 
         if "images" in data:
             data["images"] = [f"{img['path']}.{img['extension']}" for img in data["images"]]

--- a/esak/comic.py
+++ b/esak/comic.py
@@ -9,7 +9,7 @@ This module provides the following classes:
 """
 import itertools
 
-from marshmallow import INCLUDE, Schema, fields, post_load, pre_load
+from marshmallow import EXCLUDE, Schema, fields, post_load, pre_load
 from marshmallow.exceptions import ValidationError
 
 from esak import dates, exceptions, generic_summary, prices, series, text_object, urls
@@ -66,9 +66,9 @@ class ComicSchema(Schema):
     events = fields.Nested(generic_summary.GenericSummarySchema, many=True)
 
     class Meta:
-        """Any unknown fields will be included."""
+        """Any unknown fields will be excluded."""
 
-        unknown = INCLUDE
+        unknown = EXCLUDE
 
     @pre_load
     def process_input(self, data, **kwargs):

--- a/esak/comic.py
+++ b/esak/comic.py
@@ -32,27 +32,27 @@ class ComicSchema(Schema):
     """Schema for the Comic API."""
 
     id = fields.Int()
-    digitalId = fields.Int(attribute="digital_id")
+    digital_id = fields.Int(data_key="digitalId")
     title = fields.Str()
-    issueNumber = fields.Int(attribute="issue_number")
-    variantDescription = fields.Str(attribute="variant_description")
+    issue_number = fields.Int(data_key="issueNumber")
+    variant_description = fields.Str(data_key="variantDescription")
     description = fields.Str(allow_none=True)
     modified = fields.DateTime()
     isbn = fields.Str()
     upc = fields.Str()
-    diamondCode = fields.Str(attribute="diamond_code")
+    diamond_code = fields.Str(data_key="diamondCode")
     ean = fields.Str()
     issn = fields.Str()
     format = fields.Str()
-    pageCount = fields.Int(attribute="page_count")
+    page_count = fields.Int(data_key="pageCount")
     # textObjects
-    resourceURI = fields.Url(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     urls = fields.Nested(urls.UrlsSchema)
     series = fields.Nested(series.SeriesSchema)
     variants = fields.Nested(generic_summary.GenericSummarySchema, many=True)
     collections = fields.Nested(generic_summary.GenericSummarySchema, many=True)
-    collectedIssues = fields.Nested(
-        generic_summary.GenericSummarySchema, attribute="collected_issues", many=True
+    collected_issues = fields.Nested(
+        generic_summary.GenericSummarySchema, data_key="collectedIssues", many=True
     )
     dates = fields.Nested(dates.DatesSchema)
     prices = fields.Nested(prices.PriceSchemas, allow_none=True)

--- a/esak/creator.py
+++ b/esak/creator.py
@@ -31,13 +31,13 @@ class CreatorsSchema(Schema):
     """Schema for the Creator API."""
 
     id = fields.Int()
-    firstName = fields.Str(attribute="first_name")
-    middleName = fields.Str(attribute="middle_name")
-    lastName = fields.Str(attribute="last_name")
+    first_name = fields.Str(data_key="firstName")
+    middle_name = fields.Str(data_key="middleName")
+    last_name = fields.Str(data_key="lastName")
     suffix = fields.Str()
-    fullName = fields.Str(attribute="full_name")
+    full_name = fields.Str(data_key="fullName")
     modified = fields.DateTime()
-    resourceURI = fields.Str(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     # urls
     thumbnail = fields.Url()
     series = fields.Nested(generic_summary.GenericSummarySchema, many=True)

--- a/esak/dates.py
+++ b/esak/dates.py
@@ -30,9 +30,9 @@ class Dates:
 class DatesSchema(Schema):
     """Schema for the Dates."""
 
-    onsaleDate = fields.Date(attribute="on_sale")
-    focDate = fields.Date(attribute="foc")
-    unlimitedDate = fields.Date(attribute="unlimited")
+    on_sale = fields.Date(data_key="onsaleDate")
+    foc = fields.Date(data_key="focDate")
+    unlimited = fields.Date(data_key="unlimitedDate")
 
     class Meta:
         """Any unknown fields will be included."""

--- a/esak/event.py
+++ b/esak/event.py
@@ -34,7 +34,7 @@ class EventSchema(Schema):
     id = fields.Int()
     title = fields.Str()
     description = fields.Str()
-    resourceURI = fields.Str(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     # urls
     modified = fields.DateTime()
     start = fields.Date(allow_none=True)

--- a/esak/generic_summary.py
+++ b/esak/generic_summary.py
@@ -31,7 +31,7 @@ class GenericSummarySchema(Schema):
 
     id = fields.Int()
     name = fields.Str()
-    resourceURI = fields.Str(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     type = fields.Str()
     role = fields.Str()
 

--- a/esak/prices.py
+++ b/esak/prices.py
@@ -28,8 +28,8 @@ class Prices:
 class PriceSchemas(Schema):
     """Schema for the Prices."""
 
-    printPrice = fields.Decimal(places=2, attribute="print")
-    digitalPurchasePrice = fields.Decimal(places=2, attribute="digital")
+    print = fields.Decimal(places=2, data_key="printPrice")
+    digital = fields.Decimal(places=2, data_key="digitalPurchasePrice")
 
     class Meta:
         """Any unknown fields will be included."""

--- a/esak/series.py
+++ b/esak/series.py
@@ -33,10 +33,10 @@ class SeriesSchema(Schema):
     id = fields.Int()
     title = fields.Str()
     description = fields.Str(allow_none=True)
-    resourceURI = fields.Str(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     # urls
-    startYear = fields.Int(attribute="start_year", allow_none=True)
-    endYear = fields.Int(attribute="end_year", allow_none=True)
+    start_year = fields.Int(data_key="startYear", allow_none=True)
+    end_year = fields.Int(data_key="endYear", allow_none=True)
     rating = fields.Str(allow_none=True)
     modified = fields.DateTime()
     thumbnail = fields.URL(allow_none=True)

--- a/esak/stories.py
+++ b/esak/stories.py
@@ -34,7 +34,7 @@ class StoriesSchema(Schema):
     id = fields.Int()
     title = fields.Str()
     descriptions = fields.Str()
-    resourceURI = fields.Str(attribute="resource_uri")
+    resource_uri = fields.Str(data_key="resourceURI")
     type = fields.Str()
     modified = fields.DateTime()
     thumbnail = fields.Url(allow_none=True)
@@ -43,8 +43,8 @@ class StoriesSchema(Schema):
     events = fields.Nested(generic_summary.GenericSummarySchema, many=True)
     characters = fields.Nested(generic_summary.GenericSummarySchema, many=True)
     creators = fields.Nested(generic_summary.GenericSummarySchema, many=True)
-    originalIssue = fields.Nested(
-        generic_summary.GenericSummarySchema, attribute="original_issue"
+    original_issue = fields.Nested(
+        generic_summary.GenericSummarySchema, data_key="originalIssue"
     )
 
     class Meta:

--- a/esak/text_object.py
+++ b/esak/text_object.py
@@ -1,0 +1,42 @@
+"""
+TextObject module.
+
+This module provides the following classes:
+
+- TextObject
+- TextObjectSchema
+"""
+from marshmallow import Schema, fields, post_load
+
+
+class TextObject:
+    """
+    The TextObject object contains basic information.
+
+    :param `**kwargs`: The keyword arguments used for getting data from Marvel.
+    """
+
+    def __init__(self, **kwargs):
+        """Intialize a new TextObjects."""
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TextObjectSchema(Schema):
+    """Schema for the TextObject."""
+
+    type = fields.Str()
+    language = fields.Str()
+    text = fields.Str()
+
+    @post_load
+    def make(self, data, **kwargs):
+        """
+        Make the TextObject object.
+
+        :param data: Data from Marvel response.
+
+        :returns: :class:`TextObject` object
+        :rtype: TextObject
+        """
+        return TextObject(**data)

--- a/esak/urls.py
+++ b/esak/urls.py
@@ -45,10 +45,10 @@ class Urls:
 class UrlsSchema(Schema):
     """Schema for the Urls."""
 
-    digitalPurchaseDate = fields.Url(attribute="digital_purchase_date")
-    focDate = fields.Url(attribute="foc_date")
-    onsaleDate = fields.Url(attribute="onsale_date")
-    unlimitedDate = fields.Url(attribute="unlimited_date")
+    digital_purchase_date = fields.Url(data_key="digitalPurchaseDate")
+    foc_date = fields.Url(data_key="focDate")
+    onsale_date = fields.Url(data_key="onsaleDate")
+    unlimited_date = fields.Url(data_key="unlimitedDate")
     # Should these go into a separate class like CharacterUrls?
     # For now let's put them here, but it may be something to consider to split them.
     wiki = fields.Url()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "esak"
-version = "1.2.0"
+version = "1.3.0"
 description = "Marvel API wrapper for python."
 authors = ["Brian Pepple <bdpepple@gmail.com>"]
 license = "MIT"

--- a/tests/comic_test.py
+++ b/tests/comic_test.py
@@ -67,6 +67,16 @@ def test_known_comic(talker):
     )
     assert len(af15.collected_issues) < 1
     assert len(af15.variants) < 1
+    assert len(af15.text_objects) == 1
+    assert af15.text_objects[0].type == "70th_winner_desc"
+    assert af15.text_objects[0].language == "en-us"
+    assert (
+        af15.text_objects[0].text
+        == "Jack Kirby and Steve Ditko collaborated on this cover to create what "
+        "is quite possibly the most iconic image in Marvel Comics' history.  Before "
+        "all the clones, symbiotes and civil wars we see Spider-Man in a simpler time "
+        "doing what he does best, catching crooks and saving the day."
+    )
 
 
 def test_invalid_isbn(talker):

--- a/tests/comic_test.py
+++ b/tests/comic_test.py
@@ -39,6 +39,7 @@ def test_known_comic(talker):
     assert af15.description is None
     assert af15.format == "Comic"
     assert af15.id == 16926
+    assert af15.thumbnail == "http://i.annihil.us/u/prod/marvel/i/mg/f/10/598363848588e.jpg"
     assert "Spider-Man (Peter Parker)" in [c.name for c in af15.characters]
     assert "Foo" not in [c.name for c in af15.characters]
     assert "Steve Ditko" in [s.name for s in af15.creators]


### PR DESCRIPTION
Changes include:

- Use ```data_key``` instead of ```attribute``` in schemas
- Added text_object module
- Add thumbnail & text_objects field to ComicSchema